### PR TITLE
Check ret before dereferencing cqe

### DIFF
--- a/05_webserver_liburing/main.c
+++ b/05_webserver_liburing/main.c
@@ -392,9 +392,9 @@ void server_loop(int server_socket) {
 
     while (1) {
         int ret = io_uring_wait_cqe(&ring, &cqe);
-        struct request *req = (struct request *) cqe->user_data;
         if (ret < 0)
             fatal_error("io_uring_wait_cqe");
+        struct request *req = (struct request *) cqe->user_data;
         if (cqe->res < 0) {
             fprintf(stderr, "Async request failed: %s for event: %d\n",
                     strerror(-cqe->res), req->event_type);


### PR DESCRIPTION
If io_uring_wait_cqe fails, then cqe will be uninitialized, so dereferencing
it will almost certainly cause a segfault. To easily reproduce this, hit
Ctrl+Z then run `fg` immediately after starting the server, to cause it to
fail with `EINTR`.