### PR TITLE
Fix `04_cp_liburing` to track write_left correctly

### DIFF
--- a/04_cp_liburing/main.c
+++ b/04_cp_liburing/main.c
@@ -193,10 +193,10 @@ int copy_file(struct io_uring *ring, off_t insize) {
 
             if (data->read) {
                 queue_write(ring, data);
-                write_left -= data->first_len;
                 reads--;
                 writes++;
             } else {
+                write_left -= data->first_len;
                 free(data);
                 writes--;
             }


### PR DESCRIPTION
Hi, `04_cp_liburing` quits before writing file content in my environment.
Since I think `write_left` in `copy_file` should be updated when actually wrote, I moved the line and it works fine in my environment.

Thanks.